### PR TITLE
Exit if docker pull fails

### DIFF
--- a/nomad-docker-wrapper
+++ b/nomad-docker-wrapper
@@ -29,6 +29,10 @@ docker rm $NOMAD_DOCKER_CONTAINER_NAME
 if ! [ -z "$NOMAD_DOCKER_PULL_COMMAND" ]; then
   echo "Executing docker pull $NOMAD_DOCKER_PULL_COMMAND"
   docker pull $NOMAD_DOCKER_PULL_COMMAND
+  if [ $? -ne 0 ]; then
+    echo "Docker pull failed"
+    exit
+  fi
 fi
 
 if ! [ -z "$NOMAD_DOCKER_ENVSUBST" ]; then


### PR DESCRIPTION
Currently, even if `docker pull $NOMAD_DOCKER_PULL_COMMAND` fails, `nomad-docker-wrapper` is trying to run a container. This behaviour might lead to running an outdated image.

With this PR if the return code of `docker pull` is not equal to 0, `nomad-docker-wrapper` exits.

