### PR TITLE
Support docker live restore

### DIFF
--- a/nomad-docker-wrapper
+++ b/nomad-docker-wrapper
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+anywait() {
+  for pid in "$@"; do
+    while kill -0 "$pid"; do
+      sleep 0.5
+    done
+  done
+}
+
 NOMAD_DOCKER_COMMAND=$*
 
 if [ -z "$NOMAD_DOCKER_CONTAINER_NAME" ]; then
@@ -51,13 +59,12 @@ _stop() {
 echo "Trapping SIGINT, SIGTERM and SIGKILL"
 trap _stop SIGINT
 trap _stop SIGTERM
-trap _stop SIGKILL
 
 echo "Starting container $NOMAD_DOCKER_CONTAINER_NAME"
-docker run -d \
+CONTAINER_ID=$(docker run -d \
   --name $NOMAD_DOCKER_CONTAINER_NAME \
-  $NOMAD_DOCKER_COMMAND
+  $NOMAD_DOCKER_COMMAND)
 
 echo "Waiting for container $NOMAD_DOCKER_CONTAINER_NAME to finish"
-docker wait $NOMAD_DOCKER_CONTAINER_NAME &
-wait $!
+PID=$(ps aux | grep "docker-containerd-shim $CONTAINER_ID" | grep -v "grep" | awk '{print $2}')
+anywait $PID

--- a/nomad-docker-wrapper
+++ b/nomad-docker-wrapper
@@ -42,7 +42,10 @@ fi
 
 _stop() {
   echo "Stopping container $NOMAD_DOCKER_CONTAINER_NAME"
-  docker stop $NOMAD_DOCKER_CONTAINER_NAME
+  until docker stop $NOMAD_DOCKER_CONTAINER_NAME
+  do
+    sleep 1
+  done
 }
 
 echo "Trapping SIGINT, SIGTERM and SIGKILL"


### PR DESCRIPTION
If docker's live-restore feature is enabled, during the daemon restart `docker wait` as well as `docker wait` commands will fail complaining that the daemon is not available.

With this PR `nomad-docker-wrapper` is waiting for the linux host process to finish. Also, when the `SIGTERM` or `SIGINT` signals are captured, it is retrying to `docker stop` until the command succeeds.

We use `anywait` function instead of normal `wait` because the container is started by the docker daemon and `wait` works only on the child processes.