### PR TITLE
Exit if container did not start

### DIFF
--- a/nomad-docker-wrapper
+++ b/nomad-docker-wrapper
@@ -70,6 +70,6 @@ if [ $? -ne 0 ]; then
   exit
 fi
 
-echo "Waiting for container $NOMAD_DOCKER_CONTAINER_NAME to finish"
+echo "Waiting for container $NOMAD_DOCKER_CONTAINER_NAME ($CONTAINER_ID) to finish"
 PID=$(ps aux | grep "docker-containerd-shim $CONTAINER_ID" | grep -v "grep" | awk '{print $2}')
 anywait $PID

--- a/nomad-docker-wrapper
+++ b/nomad-docker-wrapper
@@ -65,6 +65,11 @@ CONTAINER_ID=$(docker run -d \
   --name $NOMAD_DOCKER_CONTAINER_NAME \
   $NOMAD_DOCKER_COMMAND)
 
+if [ $? -ne 0 ]; then
+  echo "Failed to start $NOMAD_DOCKER_CONTAINER_NAME"
+  exit
+fi
+
 echo "Waiting for container $NOMAD_DOCKER_CONTAINER_NAME to finish"
 PID=$(ps aux | grep "docker-containerd-shim $CONTAINER_ID" | grep -v "grep" | awk '{print $2}')
 anywait $PID


### PR DESCRIPTION
Currently we do not check if the container was actually started or `CONTAINER_ID` being set. When `docker run` fails, the `CONTAINER_ID` is empty. In this case we are greping for the first matching `docker-containerd-shim` and consequently waiting for the wrong container.
This PR fixes the problem.